### PR TITLE
Add basic UCI client and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-## a stockfish app
+## Stockfish Training App
+
+This repository contains a personal chess training tool powered by the official
+Stockfish engine.
+
+### Engine wrapper
+
+A minimal UCI client is available in `trainer/uci_client.py`. It can start the
+engine, set up positions and limit strength via the `UCI_Elo` option.
+
+Run it with:
+
+```bash
+python -m trainer.uci_client
+```
+
+Ensure a compiled Stockfish binary exists at `stockfish/src/stockfish` or
+provide the path when creating `StockfishEngine`.

--- a/TRACKING.md
+++ b/TRACKING.md
@@ -5,10 +5,10 @@ Stockfish.
 
 ## Tasks
 
-- [ ] Add official Stockfish engine as submodule.
-- [ ] Implement UCI client for engine communication.
+- [x] Add official Stockfish engine as submodule.
+- [x] Implement UCI client for engine communication.
 - [ ] Build GUI to display board and analysis.
-- [ ] Add ELO-based strength scaling.
+- [x] Add ELO-based strength scaling.
 - [ ] Record game history and analysis results.
 
 ## Notes

--- a/trainer/uci_client.py
+++ b/trainer/uci_client.py
@@ -1,0 +1,67 @@
+"""Simple UCI client for Stockfish engine.
+
+This module starts the Stockfish binary and exposes basic methods to send
+commands using the Universal Chess Interface (UCI) protocol. It also provides a
+helper to limit engine strength via the ``UCI_Elo`` option.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+from pathlib import Path
+from queue import Queue
+from typing import Optional
+
+
+class StockfishEngine:
+    """Minimal wrapper around the Stockfish chess engine."""
+
+    def __init__(self, path: Optional[str] = None, elo: Optional[int] = None):
+        binary = Path(path) if path else Path("stockfish/src/stockfish")
+        self.process = subprocess.Popen(
+            [str(binary)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+            bufsize=1,
+        )
+        self._queue: Queue[str] = Queue()
+        threading.Thread(target=self._reader, daemon=True).start()
+        self.send("uci")
+        self._wait_for("uciok")
+        self.send("isready")
+        self._wait_for("readyok")
+        if elo is not None:
+            self.set_elo(elo)
+
+    def _reader(self) -> None:
+        for line in self.process.stdout:
+            self._queue.put(line.strip())
+
+    def _wait_for(self, token: str) -> None:
+        while True:
+            if self._queue.get() == token:
+                return
+
+    def send(self, command: str) -> None:
+        self.process.stdin.write(command + "\n")
+        self.process.stdin.flush()
+
+    def set_elo(self, elo: int) -> None:
+        self.send("setoption name UCI_LimitStrength value true")
+        self.send(f"setoption name UCI_Elo value {elo}")
+
+    def position(self, fen: str) -> None:
+        self.send(f"position fen {fen}")
+
+    def go(self, movetime: int = 1000) -> str:
+        self.send(f"go movetime {movetime}")
+        while True:
+            line = self._queue.get()
+            if line.startswith("bestmove"):
+                return line.split()[1]
+
+    def quit(self) -> None:
+        self.send("quit")
+        self.process.wait()


### PR DESCRIPTION
## Summary
- add a minimal UCI client to launch and control the Stockfish engine
- document wrapper usage and progress in repository tracker

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68a0e6673c648328b961c83864fe206d