### PR TITLE
Add starter Next.js app with Stockfish WebAssembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ python -m trainer.uci_client
 
 Ensure a compiled Stockfish binary exists at `stockfish/src/stockfish` or
 provide the path when creating `StockfishEngine`.
+
+### Web interface
+
+A starter Next.js app lives in `next-app`. It loads the Stockfish engine in the
+browser through a WebAssembly build and serves as the base for a training UI.
+Run `npm install` and `npm run dev` inside that directory to start the server.

--- a/next-app/README.md
+++ b/next-app/README.md
@@ -1,0 +1,7 @@
+# Stockfish Trainer Next.js App
+
+This directory contains a minimal Next.js application that loads the
+Stockfish chess engine in the browser. It uses the `@lichess-org/stockfish.wasm`
+package and runs the engine inside a web worker.
+
+To try the app locally, run `npm install` followed by `npm run dev`.

--- a/next-app/app/page.jsx
+++ b/next-app/app/page.jsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Stockfish from '@lichess-org/stockfish.wasm';
+
+export default function Home() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let engine;
+    Stockfish().then((sf) => {
+      engine = sf;
+      engine.onmessage = (event) => {
+        if (event.data === 'uciok') {
+          setReady(true);
+        }
+      };
+      engine.postMessage('uci');
+    });
+    return () => engine?.terminate();
+  }, []);
+
+  return (
+    <main>
+      <h1>Stockfish Trainer</h1>
+      <p>{ready ? 'Engine ready' : 'Initializing engine...'}</p>
+    </main>
+  );
+}

--- a/next-app/next.config.js
+++ b/next-app/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    esmExternals: 'loose'
+  }
+};
+
+module.exports = nextConfig;

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "stockfish-trainer",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@lichess-org/stockfish.wasm": "^16.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal Next.js app that loads Stockfish via WebAssembly
- note web interface in top-level README

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68a0ed0bfe50832898a6bc908ab0eee9