### PR TITLE
Add FEN analysis to Next.js demo

### DIFF
--- a/next-app/README.md
+++ b/next-app/README.md
@@ -1,7 +1,12 @@
 # Stockfish Trainer Next.js App
 
 This directory contains a minimal Next.js application that loads the
-Stockfish chess engine in the browser. It uses the `@lichess-org/stockfish.wasm`
-package and runs the engine inside a web worker.
+Stockfish chess engine in the browser. It uses the
+`@lichess-org/stockfish.wasm` package and runs the engine inside a web
+worker.
+
+The main page lets you enter a FEN string and request an engine search.
+After analysing to depth 10, the app displays the best move returned by
+Stockfish.
 
 To try the app locally, run `npm install` followed by `npm run dev`.

--- a/next-app/app/page.jsx
+++ b/next-app/app/page.jsx
@@ -4,26 +4,62 @@ import { useEffect, useState } from 'react';
 import Stockfish from '@lichess-org/stockfish.wasm';
 
 export default function Home() {
+  const [engine, setEngine] = useState(null);
   const [ready, setReady] = useState(false);
+  const [fen, setFen] = useState('startpos');
+  const [bestMove, setBestMove] = useState('');
 
   useEffect(() => {
-    let engine;
+    let sfInstance;
     Stockfish().then((sf) => {
-      engine = sf;
-      engine.onmessage = (event) => {
+      sfInstance = sf;
+      setEngine(sf);
+      sf.onmessage = (event) => {
         if (event.data === 'uciok') {
           setReady(true);
+        } else if (
+          typeof event.data === 'string' &&
+          event.data.startsWith('bestmove')
+        ) {
+          const move = event.data.split(' ')[1];
+          setBestMove(move);
         }
       };
-      engine.postMessage('uci');
+      sf.postMessage('uci');
     });
-    return () => engine?.terminate();
+    return () => sfInstance?.terminate();
   }, []);
+
+  const analyze = () => {
+    if (!engine) return;
+    setBestMove('');
+    engine.postMessage('ucinewgame');
+    if (fen === 'startpos') {
+      engine.postMessage('position startpos');
+    } else {
+      engine.postMessage(`position fen ${fen}`);
+    }
+    engine.postMessage('go depth 10');
+  };
 
   return (
     <main>
       <h1>Stockfish Trainer</h1>
       <p>{ready ? 'Engine ready' : 'Initializing engine...'}</p>
+      {ready && (
+        <>
+          <label>
+            FEN or "startpos":
+            <input
+              type="text"
+              value={fen}
+              onChange={(e) => setFen(e.target.value)}
+            />
+          </label>
+          <button onClick={analyze}>Analyze</button>
+          {bestMove && <p>Best move: {bestMove}</p>}
+        </>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- allow entering FEN or start position in Next.js app
- run Stockfish search to depth 10 and show best move
- document new analysis feature in README

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68a0f012ce5483289ae59262630cb324