### PR TITLE
Add root package.json for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "workspaces": ["next-app"],
+  "scripts": {
+    "dev": "npm --workspace next-app run dev",
+    "build": "npm --workspace next-app run build",
+    "start": "npm --workspace next-app run start",
+    "vercel-build": "npm --workspace next-app run build"
+  },
+  "devDependencies": {
+    "next": "14.2.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add root package.json to expose Next.js dependency and build scripts for Vercel

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_b_68a0f3a95afc832893ba2ae5ad0925d1