### PR TITLE
Replace stockfish.wasm dependency with stockfish

### DIFF
--- a/next-app/README.md
+++ b/next-app/README.md
@@ -1,7 +1,7 @@
 # Stockfish Trainer Next.js App
 
 This directory contains a minimal Next.js application that loads the
-Stockfish chess engine in the browser. It uses the `stockfish.wasm`
+Stockfish chess engine in the browser. It uses the `stockfish` npm
 package and runs the engine inside a web worker.
 
 The main page lets you enter a FEN string and request an engine search.

--- a/next-app/app/page.jsx
+++ b/next-app/app/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Stockfish from 'stockfish.wasm';
+import Stockfish from 'stockfish';
 
 export default function Home() {
   const [engine, setEngine] = useState(null);

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -11,6 +11,6 @@
     "next": "14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "stockfish.wasm": "^16.0.0"
+    "stockfish": "^16.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- use `stockfish` npm package instead of `stockfish.wasm`
- adjust import and documentation to reference `stockfish`

## Testing
- `make test` (fails: No rule to make target 'test')
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/stockfish)


------
https://chatgpt.com/codex/tasks/task_b_68a0f7a41b1483289f283c9ecf2ece5d